### PR TITLE
fix file.name bug in postgresql migrator

### DIFF
--- a/yacore/db/postgresql/postgresql.py
+++ b/yacore/db/postgresql/postgresql.py
@@ -210,8 +210,8 @@ class DatabaseMigrator:
     def load_modules(self) -> List[Migration]:
         result = []
         for file in resources.files(self._script_location).iterdir():
-            if file != "__init__.py" and file.endswith(".py"):
-                module_name = file.removesuffix(".py")
+            if file.name != "__init__.py" and file.nameendswith(".py"):
+                module_name = file.name.removesuffix(".py")
                 module = importlib.import_module(f"{self._script_location}.{module_name}")
                 result.append(Migration.from_module(module))
         return result


### PR DESCRIPTION
Currently database migrator in postgresql.py won't work because of bug; hereby this bug is fixed
